### PR TITLE
musica - Discogs

### DIFF
--- a/_posts/2019-01-13-musica.md
+++ b/_posts/2019-01-13-musica.md
@@ -17,4 +17,9 @@ categories: jekyll update
 <li><b><a href="https://musicbrainz.org/">Banco de dados de música com conteúdo aberto</a></b>: https://musicbrainz.org/</li>
 </ul>
 
+<h2>Discogs</h2>
+<ul>
+<li><b><a href="https://www.discogs.com/">Base de dados de produção músical</a></b>: https://www.discogs.com/</li>
+</ul>
+
 </section>


### PR DESCRIPTION
Adicionando base de dados Discogs que possui dados sobre produção musical(focada em artistas e seus albums).

Todos os dados foram crowdsourced