### PR TITLE
Adição de cidades em Pernambuco

### DIFF
--- a/_states/pernambuco.md
+++ b/_states/pernambuco.md
@@ -6,3 +6,11 @@ title:  "Pernambuco"
 ### RECIFE
 
 -   **[Prefeitura de Recife](http://www2.recife.pe.gov.br/servico/portal-da-transparencia)**: http://www2.recife.pe.gov.br/servico/portal-da-transparencia
+
+### SERRA TALHADA
+
+-   **[Prefeitura de Serra Talhada](http://www.serratalhada.pe.gov.br/transparencia)**: http://www.serratalhada.pe.gov.br/transparencia
+
+### TRIUNFO
+
+-   **[Prefeitura de Triunfo](http://www.triunfo.pe.gov.br/portal-transparencia/)**: http://www.triunfo.pe.gov.br/portal-transparencia


### PR DESCRIPTION
Cidades adicionadas a Pernambuco:
- Serra Talhada
- Triunfo