### PR TITLE
Suporte ao uso do Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _site/
 Gemfile.lock
 .idea
+.bundle/

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Vamos precisar de:
 3. Digite `$ bundle install` e depois `$ bundle exec jekyll serve` no Terminal.
 3. Abra o seu navegador e digite `http://localhost:4000/`. Se tudo der certo você conseguirá ver o site rodando localmente em seu computador.
 
+## Usando o docker
+
+Uma outra opção, para quem não deseja instalar o Ruby nem o Jekyll na máquina, é usar o [Docker](https://www.docker.com/). Para isso, só é necessário rodar apenas um comando que rapidamente o servidor de desenvolvimento estará disponível. Para tanto, além do Docker, é necessário usar o [docker-compose](https://docs.docker.com/compose/). Tendo os dois instalados, é só rodar o comando `docker-compose up`.
+
 ## Colaborando com a bases de dados (e sendo uma pessoa muito legal)
 
 O **Colaboradados** é uma iniciativa sem fins lucrativos e feita para comunidade e com a ajuda da mesma. Para ajudar com nossa base de dados você precisará seguir o caminho da pasta `colaboradados.github.io/_posts` e escolher o arquivo com o nome da base para a qual você quer colaborar. Os arquivos estão em Markdown e você poderá abrir no Visual Studio Code ou em seu ambiente de desenvolvimento preferido. Os arquivos precisam ser editados seguindo **exatamente** o mesmo padrão para listas e títulos. Isso deixará o trabalho organizado e facilitará para que o [**@colaboradados**](https://twitter.com/colaboradados), nosso bot do Twitter, consiga funcionar plenamente.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.2'
+
+services:
+  colaboradados_site:
+    container_name: colaboradados-site
+    image: jekyll/builder
+    volumes:
+      - type: bind
+        source: ./
+        target: /home/jekyll
+    working_dir:  /home/jekyll
+    ports:
+      - 4000:4000
+    command: bash startup.sh

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,7 @@
+echo "Instalando dependencias"
+
+bundle install
+
+echo "Subindo Jekyll"
+
+bundle exec jekyll serve --host 0.0.0.0


### PR DESCRIPTION
Suporte ao uso do Docker com docker-compose, tendo como objetivo a facilidade em subir o servidor Jekyll.