### PR TITLE
Adicionando os links para os portais de transparência de Juiz de Fora/MG

### DIFF
--- a/_states/minas-gerais.md
+++ b/_states/minas-gerais.md
@@ -6,3 +6,10 @@ title:  "Minas Gerais"
 ### BELO HORIZONTE
 
 -   **[Prefeitura de Belo Horizonte](https://prefeitura.pbh.gov.br/transparencia)**: https://prefeitura.pbh.gov.br/transparencia/
+
+
+### JUIZ DE FORA 
+
+- **[Prefeitura de Juiz de Fora](https://www.pjf.mg.gov.br/transparencia/)**: https://www.pjf.mg.gov.br/transparencia/
+- **[Câmara Municipal de Juiz de Fora](http://www.camarajf.mg.gov.br/transparencia/)**: http://www.camarajf.mg.gov.br/transparencia/
+- **[Diário Oficial do Município de Juiz de Fora](https://www.pjf.mg.gov.br/e_atos/e_atos.php)**: https://www.pjf.mg.gov.br/e_atos/e_atos.php


### PR DESCRIPTION
Adicionando os links para os portais de transparência de transparência da Câmara Municipal e da  Prefeitura de Juiz de Fora, MG. Também foi adicionado o link para o site do diário oficial.

A branch foi criada para facilitar a moderação da equipe do Colaboradados e seguir as diretrizes da colaboração.