### PR TITLE
Portal transparência de cada cidade do Rio de Janeiro

### DIFF
--- a/_states/rio-de-janeiro.md
+++ b/_states/rio-de-janeiro.md
@@ -3,11 +3,367 @@ layout: default
 title:  "Rio de Janeiro"
 ---
 
+### ANGRA DOS REIS
+
+-   **[Prefeitura de Angra dos Reis](http://www.angra.rj.gov.br/secretaria.asp?indexsigla=transp)**: http://www.angra.rj.gov.br/secretaria.asp?indexsigla=transp
+
+### APERIBÉ
+
+-   **[Prefeitura de Aperibé](http://www.aperibe.rj.gov.br/portal)**: http://www.aperibe.rj.gov.br/portal
+
+### ARARUAMA
+
+-   **[Prefeitura de Araruama](https://www.araruama.rj.gov.br/transparencia/)**: https://www.araruama.rj.gov.br/transparencia/
+
+### AREAL
+
+-   **[Prefeitura de Areal ](http://areal.rj.gov.br/portal-da-transparencia-2/)**: http://areal.rj.gov.br/portal-da-transparencia-2/
+
+### ARMAÇÃO DOS BÚZIOS
+
+-   **[Prefeitura de Armação dos Búzios](http://www.buzios.rj.gov.br/transparencia/Default)**: http://www.buzios.rj.gov.br/transparencia/Default
+
+### ARRAIAL DO CABO
+
+-   **[Prefeitura de Arraial do Cabo ](http://186.237.32.90:2018/contaspublicas/)**: http://186.237.32.90:2018/contaspublicas/
+
+### BARRA DO PIRAÍ
+
+-   **[Prefeitura de Barra do Piraí ](http://transparencia.portalbarradopirai.com.br/index.php/pt/)**: http://transparencia.portalbarradopirai.com.br/index.php/pt/
+
+### BARRA MANSA
+
+-   **[Prefeitura de Barra Mansa ](http://www.barramansa.rj.gov.br/transparencia/index.php/en/)**: http://www.barramansa.rj.gov.br/transparencia/index.php/en/
+
+### BOM JARDIM
+
+-   **[Prefeitura de Bom Jardim ](http://www.bomjardim.rj.gov.br/e-sic/)**: http://www.bomjardim.rj.gov.br/e-sic/
+
+### BOM JESUS DO ITABAPOANA
+
+-   **[Prefeitura de Bom Jesus do Itabapoana](http://transparencia.bomjesus.rj.gov.br:8079/transparencia)**: http://transparencia.bomjesus.rj.gov.br:8079/transparencia
+
+### CABO FRIO
+
+-   **[Prefeitura de Cabo Frio ](http://cabofrio.rj.gov.br/transparencia/)**: http://cabofrio.rj.gov.br/transparencia/
+
+### CACHOEIRAS DE MACACU
+
+-   **[Prefeitura de Cachoeiras de Macacu](https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=NmwYKTAEBjQ=)**: https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=NmwYKTAEBjQ=
+
+### CAMBUCI
+
+-   **[Prefeitura de Cambuci](http://prefeituradecambuci.rj.gov.br/transparencia/)**: http://prefeituradecambuci.rj.gov.br/transparencia/
+
+### CAMPOS DOS GOYTACAZES
+
+-   **[Prefeitura de Campos dos Goytacazes ](https://transparencia.campos.rj.gov.br/home)**: https://transparencia.campos.rj.gov.br/home
+
+### CANTAGALO
+
+-   **[Prefeitura de Cantagalo ](https://www.cantagalo.rj.gov.br/transparencia)**: https://www.cantagalo.rj.gov.br/transparencia
+
+### CARAPEBUS
+
+-   **[Prefeitura de Carapebus ](http://pt.carapebus.rj.gov.br/)**: http://pt.carapebus.rj.gov.br/
+
+### CARDOSO MOREIRA
+
+-   **[Prefeitura de Cardoso Moreira ](http://transparencia.cardosomoreira.rj.gov.br:8079/transparencia/)**: http://transparencia.cardosomoreira.rj.gov.br:8079/transparencia/
+
+### CARMO
+
+-   **[Prefeitura de Carmo](http://www.carmo.rj.gov.br/transparencia)**: http://www.carmo.rj.gov.br/transparencia
+
+### CASIMIRO DE ABREU
+
+-   **[Prefeitura de Casimiro de Abreu](http://transparencia.casimirodeabreu.rj.gov.br/)**: http://transparencia.casimirodeabreu.rj.gov.br/
+
+### COMENDADOR LEVY GASPARIAN
+
+-   **[Prefeitura de Comendador Levy Gasparian](http://pt.levygasparian.rj.gov.br/)**: http://pt.levygasparian.rj.gov.br/
+
+### CONCEIÇÃO DE MACABU
+
+-   **[Prefeitura de Conceição de Macabu](http://pt.conceicaodemacabu.rj.gov.br/)**: http://pt.conceicaodemacabu.rj.gov.br/
+
+### CORDEIRO
+
+-   **[Prefeitura de Cordeiro ](http://www.cordeiro.rj.gov.br/portal)**: http://www.cordeiro.rj.gov.br/portal
+
+### DUAS BARRAS
+
+-   **[Prefeitura de Duas Barras ](http://www.duasbarras.rj.gov.br/portal)**: http://www.duasbarras.rj.gov.br/portal
+
+### DUQUE DE CAXIAS
+
+-   **[Prefeitura de Duque de Caxias ](http://transparencia.duquedecaxias.rj.gov.br/)**: http://transparencia.duquedecaxias.rj.gov.br/
+
+### ENGENHEIRO PAULO DE FRONTIN
+
+-   **[Prefeitura de Engenheiro Paulo de Frontin](https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=LM2jR8s96JlZWH5V0U0nBOKj-tSyQHef)**: https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=LM2jR8s96JlZWH5V0U0nBOKj-tSyQHef
+
+### GUAPIMIRIM
+
+-   **[Prefeitura de Guapimirim ](http://guapimirim.rj.gov.br/transparencia/)**: http://guapimirim.rj.gov.br/transparencia/
+
+### IGUABA GRANDE
+
+-   **[Prefeitura de Iguaba Grande](http://digital.iguaba.rj.gov.br/)**: http://digital.iguaba.rj.gov.br/
+
+### ITABORAÍ
+
+-   **[Prefeitura de Itaboraí ](https://www.itaborai.rj.gov.br/cidade-transparente/)**: https://www.itaborai.rj.gov.br/cidade-transparente/
+
+### ITAGUAÍ
+
+-   **[Prefeitura de Itaguaí ](http://transparencia.itaguai.rj.gov.br/)**: http://transparencia.itaguai.rj.gov.br/
+
+### ITALVA
+
+-   **[Prefeitura de Italva ](http://transparencia.italva.rj.gov.br/pronimtb/index.asp)**: http://transparencia.italva.rj.gov.br/pronimtb/index.asp
+
+### ITAOCARA
+
+-   **[Prefeitura de Itaocara ](http://itaocara.rj.gov.br/transparencia/)**: http://itaocara.rj.gov.br/transparencia/
+
+### ITAPERUNA
+
+-   **[Prefeitura de Itaperuna ](http://177.223.12.122:81/pronimtb/)**: http://177.223.12.122:81/pronimtb/
+
+### ITATIAIA
+
+-   **[Prefeitura de Itatiaia ](https://itatiaia.rj.gov.br/acesso-a-informacao)**: https://itatiaia.rj.gov.br/acesso-a-informacao
+
+### JAPERI
+
+-   **[Prefeitura de Japeri ](http://www.japeri.rj.gov.br/novatransparencia/)**: http://www.japeri.rj.gov.br/novatransparencia/
+
+### LAJE DO MURIAÉ
+
+-   **[Prefeitura de Laje do Muriaé ](http://laje.rj.gov.br/transparencia/)**: http://laje.rj.gov.br/transparencia/
+
+### MACAÉ
+
+-   **[Prefeitura de Macaé ](http://sistemas.macae.rj.gov.br:84/transparencia/)**: http://sistemas.macae.rj.gov.br:84/transparencia/
+
+### MACUCO
+
+-   **[Prefeitura de Macuco ](http://prefeituramacuco.rj.gov.br/prefpop/index.html)**: http://prefeituramacuco.rj.gov.br/prefpop/index.html
+
+### MAGÉ
+
+-   **[Prefeitura de Magé ](http://transparencia.mage.rj.gov.br/)**: http://transparencia.mage.rj.gov.br/
+
+### MANGARATIBA
+
+-   **[Prefeitura de Mangaratiba ](https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=WppxBH47Kza1Cw1lEux3UylrmoIL_iuG)**: https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=WppxBH47Kza1Cw1lEux3UylrmoIL_iuG
+
+### MARICÁ
+
+-   **[Prefeitura de Maricá ](http://ecidadeonline.marica.rj.gov.br/e-cidade_transparencia_inte/)**: http://ecidadeonline.marica.rj.gov.br/e-cidade_transparencia_inte/
+
+### MENDES
+
+-   **[Prefeitura de Mendes ](http://www.mendes.rj.gov.br/234)**: http://www.mendes.rj.gov.br/234
+
+### MESQUITA
+
+-   **[Prefeitura de Mesquita ](http://transparencia.mesquita.rj.gov.br/)**: http://transparencia.mesquita.rj.gov.br/
+
+### MIGUEL PEREIRA
+
+-   **[Prefeitura de Miguel Pereira](http://transparencia.pmmp.rj.gov.br/)**: http://transparencia.pmmp.rj.gov.br/
+
+### MIRACEMA
+
+-   **[Prefeitura de Miracema ](http://miracema.rj.gov.br/transparencia/)**: http://miracema.rj.gov.br/transparencia/
+
+### NATIVIDADE
+
+-   **[Prefeitura de Natividade](http://179.109.158.34:8079/transparencia/)**: http://179.109.158.34:8079/transparencia/
+
+### NILÓPOLIS
+
+-   **[Prefeitura de Nilópolis ](http://nilopolis.rj.gov.br/site/transparencia/)**: http://nilopolis.rj.gov.br/site/transparencia/
+
+### NITERÓI
+
+-   **[Prefeitura de Niterói](http://portais.niteroi.rj.gov.br/portal-da-transparencia/)**: http://portais.niteroi.rj.gov.br/portal-da-transparencia/
+
+### NOVA FRIBURGO
+
+-   **[Prefeitura de Nova Friburgo](http://transparencia.pmnf.rj.gov.br/)**: http://transparencia.pmnf.rj.gov.br/
+
+### NOVA IGUAÇU
+
+-   **[Prefeitura de Nova Iguaçu ](http://dstec01.cloudapp.net/esiclivre/)**: http://dstec01.cloudapp.net/esiclivre/
+
+### PARACAMBI
+
+-   **[Prefeitura de Paracambi](https://paracambi.ccanet.com.br/transparencia)**: https://paracambi.ccanet.com.br/transparencia
+
+### PARAÍBA DO SUL
+
+-   **[Prefeitura de Paraíba do Sul](http://paraibadosul.rj.gov.br/transparencia)**: http://paraibadosul.rj.gov.br/transparencia
+
+### PARATY
+
+-   **[Prefeitura de Paraty ](http://pmparaty.web2382.uni5.net/blogtransparencia/index.aspx)**: http://pmparaty.web2382.uni5.net/blogtransparencia/index.aspx
+
+### PATY DO ALFERES
+
+-   **[Prefeitura de Paty do Alferes ](http://200.199.78.2/e-cidade_transparencia/)**: http://200.199.78.2/e-cidade_transparencia/
+
+### PETRÓPOLIS
+
+-   **[Prefeitura de Petrópolis ](http://www.petropolis.rj.gov.br/pmp/index.php/transparencia-servico/home-transparencia.html)**: http://www.petropolis.rj.gov.br/pmp/index.php/transparencia-servico/home-transparencia.html
+
+### PINHEIRAL
+
+-   **[Prefeitura de Pinheiral ](http://www.pinheiral.rj.gov.br/PortalTransparencia/)**: http://www.pinheiral.rj.gov.br/PortalTransparencia/
+
+### PIRAÍ
+
+-   **[Prefeitura de Piraí ](https://transparencia.pirai.rj.gov.br/)**: https://transparencia.pirai.rj.gov.br/
+
+### PORCIÚNCULA
+
+-   **[Prefeitura de Porciúncula ](http://transparencia.porciuncula.rj.gov.br:8079/transparencia)**: http://transparencia.porciuncula.rj.gov.br:8079/transparencia
+
+### PORTO REAL
+
+-   **[Prefeitura de Porto Real ](http://s2.asp.srv.br/etransparencia.pm.portoreal.rj/servlet/portal)**: http://s2.asp.srv.br/etransparencia.pm.portoreal.rj/servlet/portal
+
+### QUATIS
+
+-   **[Prefeitura de Quatis](transparencia.quatis.rj.gov.bcr)**: transparencia.quatis.rj.gov.bcr
+
+### QUEIMADOS
+
+-   **[Prefeitura de Queimados](http://semad.queimados.rj.gov.br/)**: http://semad.queimados.rj.gov.br/
+
+### QUISSAMÃ
+
+-   **[Prefeitura de Quissamã ](http://transparencia.quissama.rj.gov.br/contaspublicas/)**: http://transparencia.quissama.rj.gov.br/contaspublicas/
+
+### RESENDE
+
+-   **[Prefeitura de Resende ](http://resende.rj.gov.br/blogtransparencia/page/index.asp)**: http://resende.rj.gov.br/blogtransparencia/page/index.asp
+
+### RIO BONITO
+
+-   **[Prefeitura de Rio Bonito ](https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=ZNMCq9WbIVc=)**: https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=ZNMCq9WbIVc=
+
+### RIO CLARO
+
+-   **[Prefeitura de Rio Claro ](https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=vmkUEqRPbWusgJfn2UjAO_5-6qALcbpz)**: https://e-gov.betha.com.br/transparencia/01037-004/recursos.faces?mun=vmkUEqRPbWusgJfn2UjAO_5-6qALcbpz
+
+### RIO DAS FLÔRES
+
+-   **[Prefeitura de Rio das Flôres](http://transparenciapmrf.primaxonline.com.br/)**: http://transparenciapmrf.primaxonline.com.br/
+
+### RIO DAS OSTRAS
+
+-   **[Prefeitura de Rio das Ostras ](https://www.riodasostras.rj.gov.br/transparencia/)**: https://www.riodasostras.rj.gov.br/transparencia/
+
 ### RIO DE JANEIRO
 
 -   **[Prefeitura do Rio de Janeiro](http://prefeitura.rio/web/transparenciacarioca)**: http://prefeitura.rio/web/transparenciacarioca
 -   **[DATA.Rio](http://www.data.rio/)**: http://www.data.rio/
 
-### NITERÓI
+### SANTA MARIA MADALENA
 
--   **[Prefeitura de Niterói](http://portais.niteroi.rj.gov.br/portal-da-transparencia/)**: http://portais.niteroi.rj.gov.br/portal-da-transparencia/
+-   **[Prefeitura de Santa Maria Madalena](https://www.pmsmm.rj.gov.br/portal_transparencia)**: https://www.pmsmm.rj.gov.br/portal_transparencia
+
+### SANTO ANTÔNIO DE PÁDUA
+
+-   **[Prefeitura de Santo Antônio de Pádua ](http://santoantoniodepadua.rj.gov.br/transparencia/)**: http://santoantoniodepadua.rj.gov.br/transparencia/
+
+### SÃO FIDÉLIS
+
+-   **[Prefeitura de São Fidélis](http://177.66.89.34:8079/Transparencia/)**: http://177.66.89.34:8079/Transparencia/
+
+### SÃO FRANCISCO DE ITABAPOANA
+
+-   **[Prefeitura de São Francisco de Itabapoana](http://www.pmsfi.rj.gov.br/portal-da-transparencia/)**: http://www.pmsfi.rj.gov.br/portal-da-transparencia/
+
+### SÃO GONÇALO
+
+-   **[Prefeitura de São Gonçalo ](http://www.pmsg.rj.gov.br/transparencia/)**: http://www.pmsg.rj.gov.br/transparencia/
+
+### SÃO JOÃO DA BARRA
+
+-   **[Prefeitura de São João da Barra](https://saojoaodabarra-rj.portaltp.com.br/consultas/institucional/arquivo.aspx)**: https://saojoaodabarra-rj.portaltp.com.br/consultas/institucional/arquivo.aspx
+
+### SÃO JOÃO DE MERITI
+
+-   **[Prefeitura de São João de Meriti](http://transparencia.meriti.rj.gov.br/?serv=28)**: http://transparencia.meriti.rj.gov.br/?serv=28
+
+### SAO JOSÉ DE UBÁ
+
+-   **[Prefeitura de Sao José de Ubá ](http://pt.saojosedeuba.rj.gov.br/pronimtb/)**: http://pt.saojosedeuba.rj.gov.br/pronimtb/
+
+### SÃO JOSÉ DO VALE DO RIO PRETO
+
+-   **[Prefeitura de São José do Vale do Rio Preto ](https://e-gov.betha.com.br/transparencia/01037-005/recursos.faces)**: https://e-gov.betha.com.br/transparencia/01037-005/recursos.faces
+
+### SÃO PEDRO DA ALDEIA
+
+-   **[Prefeitura de São Pedro da Aldeia](http://transparencia.pmspa.rj.gov.br/)**: http://transparencia.pmspa.rj.gov.br/
+
+### SÃO SEBASTIÃO DO ALTO
+
+-   **[Prefeitura de São Sebastião do Alto](http://ssalto.rj.gov.br/portal-da-transparencia/)**: http://ssalto.rj.gov.br/portal-da-transparencia/
+
+### SAPUCAIA
+
+-   **[Prefeitura de Sapucaia ](http://sapucaia.rj.gov.br/servicos/index.html)**: http://sapucaia.rj.gov.br/servicos/index.html
+
+### SAQUAREMA
+
+-   **[Prefeitura de Saquarema ](http://transparencia.saquarema.rj.gov.br/)**: http://transparencia.saquarema.rj.gov.br/
+
+### SEROPÉDICA
+
+-   **[Prefeitura de Seropédica](http://transparencia.seropedica.rj.gov.br/)**: http://transparencia.seropedica.rj.gov.br/
+
+### SILVA JARDIM
+
+-   **[Prefeitura de Silva Jardim ](http://cidadao.silvajardim.rj.gov.br/pronimtb/index.asp)**: http://cidadao.silvajardim.rj.gov.br/pronimtb/index.asp
+
+### SUMIDOURO
+
+-   **[Prefeitura de Sumidouro ](http://www.sumidouro.rj.gov.br/menu-transparencia/)**: http://www.sumidouro.rj.gov.br/menu-transparencia/
+
+### TANGUÁ
+
+-   **[Prefeitura de Tanguá ](https://tangua.rj.gov.br/transparencia/)**: https://tangua.rj.gov.br/transparencia/
+
+### TERESÓPOLIS
+
+-   **[Prefeitura de Teresópolis](https://teresopolis.rj.gov.br/transparencia/)**: https://teresopolis.rj.gov.br/transparencia/
+
+### TRAJANO DE MORAES
+
+-   **[Prefeitura de Trajano de Moraes](https://trajanotransparente.rj.gov.br/)**: https://trajanotransparente.rj.gov.br/
+
+### TRÊS RIOS
+
+-   **[Prefeitura de Três Rios](http://transparencia-pmtr.sgpsystems.com.br/)**: http://transparencia-pmtr.sgpsystems.com.br/
+
+### VALENÇA
+
+-   **[Prefeitura de Valença](http://www.valenca.rj.gov.br/transparencia/)**: http://www.valenca.rj.gov.br/transparencia/
+
+### VARRE-SAI
+
+-   **[Prefeitura de Varre-Sai](http://transparencia.varresai.rj.gov.br:8090/pronimtb/)**: http://transparencia.varresai.rj.gov.br:8090/pronimtb/
+
+### VASSOURAS
+
+-   **[Prefeitura de Vassouras](http://186.226.210.213/pronimtb/)**: http://186.226.210.213/pronimtb/
+
+### VOLTA REDONDA
+
+-   **[Prefeitura de Volta Redonda](http://www.voltaredonda.rj.gov.br/transparencia/)**: http://www.voltaredonda.rj.gov.br/transparencia/


### PR DESCRIPTION
Adicionei o link para os portais de transparência de cada cidade do estado do Rio de Janeiro. 

A lista de cidades e links para prefeituras foram lidas da página http://www.rj.gov.br/web/guest/exibeconteudo?article-id=133102

Não consegui acessar a página da prefeitura de **Belford Roxo**.