### PR TITLE
Adição de cidades em Pernambuco e IMDB

### DIFF
--- a/_posts/2019-01-18-cinema.md
+++ b/_posts/2019-01-18-cinema.md
@@ -17,3 +17,7 @@ img: cinema
 ## MNEMOCINE
 
 -   **[Base de dados de filmes estrangeiros exibidos no país entre o Omniógrafo (1896) e a passagem ao sonoro (1934)](http://silenciosos.l2o.com.br/cgi-bin/wxis.exe/iah/scripts/?IsisScript=iah.xis&lang=pt&base=VIDEO)**: http://silenciosos.l2o.com.br/cgi-bin/wxis.exe/iah/scripts/?IsisScript=iah.xis&lang=pt&base=VIDEO
+
+## IMDB
+
+- **[ Base de dados do Internet Movie Database](https://www.imdb.com/interfaces/)**: https://www.imdb.com/interfaces/

--- a/_states/pernambuco.md
+++ b/_states/pernambuco.md
@@ -2,3 +2,15 @@
 layout: default
 title:  "Pernambuco"
 ---
+
+### SALGUEIRO
+
+- **[Prefeitura de Salgueiro](http://www.salgueiro.pe.gov.br/transparencia/index.htm)**: http://www.salgueiro.pe.gov.br/transparencia/index.htm
+
+### PETROLINA
+
+- **[Prefeitura de Petrolina](http://transparencia.petrolina.pe.gov.br/)**: http://transparencia.petrolina.pe.gov.br/
+
+### JABOATÃO DOS GUARARAPES
+
+- **[Prefeitura de Jaboatão dos Guararapes](https://portaldatransparencia.jaboatao.pe.gov.br/)**: https://portaldatransparencia.jaboatao.pe.gov.br/


### PR DESCRIPTION
Adição das cidades de Salgueiro, Petrolina e Jaboatão dos Guararapes. 
Adição da base do IMDB (Internet Movie Database)