### PR TITLE
acrescenta download de dados abertos do Portal da Transparência

### DIFF
--- a/_posts/2019-01-21-esfera-federal.md
+++ b/_posts/2019-01-21-esfera-federal.md
@@ -10,6 +10,7 @@ img: esfera-federal
 
 -   **[Portal Brasileiro de Dados Abertos](http://dados.gov.br/)**: http://dados.gov.br/
 -   **[Portal da Transparência](http://portaldatransparencia.gov.br/)**: http://portaldatransparencia.gov.br/
+  -   **[Dados Abertos do Portal da Transparência](http://www.transparencia.gov.br/download-de-dados)**: http://www.transparencia.gov.br/download-de-dados
 -   **[Diário Oficial da União](http://www.in.gov.br/web/guest/inicio)**: http://www.in.gov.br/web/guest/inicio
 
 ## MINISTÉRIO DA CIDADANIA


### PR DESCRIPTION
seria útil apontar diretamente para a área de download de dados do Portal da Transparência, já que o foco do site é colaborar sobre *dados*