### PR TITLE
Adicionados vários municípios da Paraíba

### DIFF
--- a/_states/paraiba.md
+++ b/_states/paraiba.md
@@ -7,7 +7,68 @@ title:  "Paraíba"
 
 -   **[Portal da Transparência do Município de João Pessoa](https://transparencia.joaopessoa.pb.gov.br/#/)**: https://transparencia.joaopessoa.pb.gov.br/#/
 
+-   **[Semanário Oficial do Município de João Pessoa](http://www.joaopessoa.pb.gov.br/semanariooficial/)**: http://www.joaopessoa.pb.gov.br/semanariooficial/
+
+-   **[Portal da Transparência da Câmara Municipal de João Pessoa](https://transparencia.elmartecnologia.com.br/?e=101095)**: https://transparencia.elmartecnologia.com.br/?e=101095
+
+-   **[Semanário Oficial da Câmara Municipal de João Pessoa](https://cmjp.pb.gov.br/diario-oficial/)**: https://cmjp.pb.gov.br/diario-oficial/
+
+
 ### Campina Grande
 
 -   **[Portal da Transparência do Município de Campina Grande](http://campinagrande.pb.gov.br/portal-da-transparencia/)**: http://campinagrande.pb.gov.br/portal-da-transparencia/
+
+-   **[Semanário Oficial do Município de Campina Grande](http://campinagrande.pb.gov.br/semanario-oficial/)**: http://campinagrande.pb.gov.br/semanario-oficial/
+
+-   **[Portal da Transparência da Câmara Municipal de Campina Grande](https://www.camaracg.pb.gov.br/transparencia/)**: https://www.camaracg.pb.gov.br/transparencia/
+
+
+### Santa Rita
+
+-   **[Portal da Transparência do Município de Santa Rita](https://www.santarita.pb.gov.br/transparencia/portal-da-transparencia/)**: https://www.santarita.pb.gov.br/transparencia/portal-da-transparencia/
+
+
+### Cajazeiras
+
+-   **[Portal da Transparência do Município de Cajazeiras](https://cajazeiras.pb.gov.br/transparencia/)**: https://cajazeiras.pb.gov.br/transparencia/
+
+
+### Itabaiana
+
+-   **[Portal da Transparência do Município de Itabaiana](http://transparencia.itabaiana.pb.gov.br/)**: http://transparencia.itabaiana.pb.gov.br/
+
+
+### Ingá
+
+-   **[Portal da Transparência do Município de Ingá](https://inga.pb.gov.br/portal-da-transparencia/)**: https://inga.pb.gov.br/portal-da-transparencia/
+
+
+### Mamanguape
+
+-   **[Portal da Transparência do Município de Mamanguape](https://transparencia.mamanguape.pb.gov.br/)**: https://transparencia.mamanguape.pb.gov.br/
+
+
+### Guarabira
+
+-   **[Portal da Transparência do Município de Guarabira](http://www.guarabira.pb.gov.br/portaldatransparencia/)**: http://www.guarabira.pb.gov.br/portaldatransparencia/
+
+
+### Sousa
+
+-   **[Portal da Transparência do Município de Sousa](http://sousa.pb.gov.br/cont.php?pagina=transparencia)**: http://sousa.pb.gov.br/cont.php?pagina=transparencia
+
+
+### Picuí
+
+-   **[Portal da Transparência do Município de Picuí](https://www.picui.pb.gov.br/portal/transparencia-fiscal)**: https://www.picui.pb.gov.br/portal/transparencia-fiscal
+
+
+### Patos
+
+-   **[Portal da Transparência do Município de Patos](http://patos.pb.gov.br/servicos/portal_da_transparencia)**: http://patos.pb.gov.br/servicos/portal_da_transparencia
+
+
+### Pombal
+
+-   **[Portal da Transparência do Município de Pombal](http://pombal.pb.gov.br/transparencia/)**: http://pombal.pb.gov.br/transparencia/
 


### PR DESCRIPTION
Adicionados vários portais de transparência de municípios do interior do estado, bem como semanários oficiais de algumas prefeituras e câmaras municipais. Espero que esteja tudo em conformidade com os padrões. Qualquer modificação necessária é só falar.
