### PR TITLE
Links dos portais de transparência dos municípios de Rondônia

### DIFF
--- a/_states/rondonia.md
+++ b/_states/rondonia.md
@@ -7,3 +7,314 @@ title:  "Rondônia"
 
 -   **[Portal da Transparência do Município de Porto Velho](http://transparencia.portovelho.ro.gov.br/Site/Principal/)**: http://transparencia.portovelho.ro.gov.br/Site/Principal/
 
+-   **[Portal da Transparência da Câmara Municipal de Porto Velho](http://transparencia.portovelho.ro.leg.br/)**: http://transparencia.portovelho.ro.leg.br/
+
+### Alta Floresta D'Oeste
+
+-   **[Portal de Transparência do Município de Alta Floresta D'Oeste](https://transparencia.altaflorestadoeste.ro.gov.br/)**: https://transparencia.altaflorestadoeste.ro.gov.br/
+
+-   **[Portal da Transparência da Câmara Municipal de Alta Floresta D'Oeste](http://transparencia.altaflorestadoeste.ro.leg.br/)**: http://transparencia.altaflorestadoeste.ro.leg.br/
+
+### Ariquemes
+
+-   **[Portal de Transparência do Município de Ariquemes](http://transparencia.ariquemes.ro.gov.br/transparencia/)**: http://transparencia.ariquemes.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Ariquemes](http://transparencia.camaradeariquemes.ro.gov.br/)**: http://transparencia.camaradeariquemes.ro.gov.br/
+
+### Cabixi
+
+-   **[Portal de Transparência do Município de Cabixi](http://transparencia.cabixi.ro.gov.br/)**: http://transparencia.cabixi.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Cabixi](http://transparencia.cabixi.ro.leg.br/transparencia/)**: http://transparencia.cabixi.ro.leg.br/transparencia/
+
+### Cacoal
+
+-   **[Portal de Transparência do Município de Cacoal](https://transparencia.cacoal.ro.gov.br/)**: https://transparencia.cacoal.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Cacoal](http://transparencia.cacoal.ro.leg.br/portaltransparencia/)**: http://transparencia.cacoal.ro.leg.br/portaltransparencia/
+
+### Cerejeiras
+
+-   **[Portal de Transparência do Município de Cerejeiras](http://transparencia.cerejeiras.ro.gov.br/)**: http://transparencia.cerejeiras.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Cerejeiras](http://transparencia.cerejeiras.ro.leg.br/transparencia/)**: http://transparencia.cerejeiras.ro.leg.br/transparencia/
+
+### Colorado do Oeste
+
+-   **[Portal de Transparência do Município de Colorado do Oeste](http://transparencia.coloradodooeste.ro.gov.br/transparencia/)**: http://transparencia.coloradodooeste.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Colorado do Oeste](http://transparencia.coloradodooeste.ro.leg.br/portaltransparencia/)**: http://transparencia.coloradodooeste.ro.leg.br/portaltransparencia/
+
+### Corumbiara
+
+-   **[Portal de Transparência do Município de Corumbiara](http://transparencia.corumbiara.ro.gov.br/)**: http://transparencia.corumbiara.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Corumbiara](http://transparencia.corumbiara.ro.leg.br/transparencia/)**: http://transparencia.corumbiara.ro.leg.br/transparencia/
+
+### Costa Marques
+
+-   **[Portal de Transparência do Município de Costa Marques](http://transparencia.costamarques.ro.gov.br/)**: http://transparencia.costamarques.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Costa Marques](http://138.121.27.59:8080/portaltransparencia/)**: http://138.121.27.59:8080/portaltransparencia/
+
+### Espigão D'Oeste (ou Espigão do Oeste)
+
+-   **[Portal de Transparência do Município de Espigão D'Oeste](http://transparencia.espigaodooeste.ro.gov.br/transparencia/)**: http://transparencia.espigaodooeste.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Espigão D'Oeste](http://177.129.125.89/portaltransparencia/)**: http://177.129.125.89/portaltransparencia/
+
+### Guajará-Mirim
+
+-   **[Portal de Transparência do Município de Guajará-Mirim](http://transparencia.guajaramirim.ro.gov.br/transparencia/)**: http://transparencia.guajaramirim.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Guajará-Mirim](http://200.96.206.197:8079/TRANSPARENCIA/)**: http://200.96.206.197:8079/TRANSPARENCIA/
+
+### Jaru
+
+-   **[Portal de Transparência do Município de Jaru](http://transparencia.jaru.ro.gov.br/transparencia/)**: http://transparencia.jaru.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Jaru](http://177.203.133.115:5659/transparencia/)**: http://177.203.133.115:5659/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Jaru - Arquivo](http://177.203.133.115/portaltransparencia//)**: http://177.203.133.115/portaltransparencia// <sup>1</sup>
+
+<sup>1</sup>: Arquivo do Portal de Transparência, que possui dados de transparência até 10 de abril de 2018
+
+### Ji-Paraná
+
+-   **[Portal de Transparência do Município de Ji-Paraná](http://transparencia.ji-parana.ro.gov.br/transparencia/)**: http://transparencia.ji-parana.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Ji-Paraná](http://transparencia.jiparana.ro.leg.br/transparencia/)**: http://transparencia.jiparana.ro.leg.br/transparencia/
+
+### Machadinho D'Oeste
+
+-   **[Portal de Transparência do Município de Machadinho d'Oeste](http://www.transparencia.machadinho.ro.gov.br/)**: http://www.transparencia.machadinho.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Machadinho d'Oeste](http://transparencia.camarademachadinho.ro.gov.br/)**: http://transparencia.camarademachadinho.ro.gov.br/
+
+### Nova Brasilândia D'Oeste
+
+-   **[Portal de Transparência do Município de Nova Brasilândia D'Oeste](https://transparencia.novabrasilandia.ro.gov.br/portaltransparencia/)**: https://transparencia.novabrasilandia.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Nova Brasilândia D'Oeste](http://transparencia.camaranbo.ro.gov.br/portaltransparencia/)**: http://transparencia.camaranbo.ro.gov.br/portaltransparencia/
+
+### Ouro Preto do Oeste
+
+-   **[Portal de Transparência do Município de Ouro Preto Do Oeste](http://transparencia.ouropretodooeste.ro.gov.br/transparencia/)**: http://transparencia.ouropretodooeste.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Ouro Preto do Oeste](http://179.253.49.222:5659/transparencia/)**: http://179.253.49.222:5659/transparencia/
+
+### Pimenta Bueno
+
+-   **[Portal de Transparência do Município de Pimenta Bueno](http://transparencia.pimentabueno.ro.gov.br/portaltransparencia/)**: http://transparencia.pimentabueno.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Pimenta Bueno](http://transparencia.pimentabueno.ro.leg.br/portaltransparencia/)**: http://transparencia.pimentabueno.ro.leg.br/portaltransparencia/
+
+### Presidente Médici
+
+-   **[Portal de Transparência do Município de Presidente Médici](http://www.transparencia.presidentemedici.ro.gov.br/transparencia/)**: http://www.transparencia.presidentemedici.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Presidente Médici](http://transparencia.camaramedici.ro.gov.br/)**: http://transparencia.camaramedici.ro.gov.br/
+
+### Rio Crespo
+
+-   **[Portal de Transparência do Município de Rio Crespo](http://transparencia.riocrespo.ro.gov.br/portaltransparencia/)**: http://transparencia.riocrespo.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Rio Crespo](http://transparencia.camarariocrespo.ro.gov.br/)**: http://transparencia.camarariocrespo.ro.gov.br/
+
+### Rolim de Moura
+
+-   **[Portal de Transparência do Município de Rolim de Moura](http://transparencia.rolimdemoura.ro.gov.br/)**: http://transparencia.rolimdemoura.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Rolim de Moura](http://transparencia.rolimdemoura.ro.leg.br/)**: http://transparencia.rolimdemoura.ro.leg.br/
+
+### Santa Luzia D'Oeste
+
+-   **[Portal de Transparência do Município de Santa Luzia D'Oeste](http://transparencia.santaluzia.ro.gov.br/)**: http://transparencia.santaluzia.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Santa Luzia D'Oeste](http://transparencia.abase.com.br/home/paginaInicial/nmRX5BhveQo=)**: http://transparencia.abase.com.br/home/paginaInicial/nmRX5BhveQo=
+
+### Vilhena
+
+-   **[Portal de Transparência do Município de Vilhena](http://transparencia.vilhena.ro.gov.br/)**: http://transparencia.vilhena.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Vilhena](http://transparencia.vilhena.ro.leg.br/)**: http://transparencia.vilhena.ro.leg.br/
+
+### São Miguel do Guaporé
+
+-   **[Portal de Transparência do Município de São Miguel do Guaporé](http://transparencia.saomiguel.ro.gov.br/portaltransparencia/)**: http://transparencia.saomiguel.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de São Miguel do Guaporé](http://transparencia.saomigueldoguapore.ro.leg.br/)**: http://transparencia.saomigueldoguapore.ro.leg.br/
+
+### Nova Mamoré
+
+-   **[Portal de Transparência do Município de Nova Mamoré](http://transparencia.novamamore.ro.gov.br/)**: http://transparencia.novamamore.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Nova Mamoré](http://transparencia.novamamore.ro.leg.br/transparencia/index.php)**: http://transparencia.novamamore.ro.leg.br/transparencia/index.php
+
+### Alvorada D'Oeste
+
+-   **[Portal de Transparência do Município de Alvorada D'Oeste](http://transparencia.alvoradadooeste.ro.gov.br/)**: http://transparencia.alvoradadooeste.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Alvorada D'Oeste](http://transparencia.camaradealvorada.ro.gov.br/)**: http://transparencia.camaradealvorada.ro.gov.br/
+
+### Alto Alegre dos Parecis
+
+-   **[Portal de Transparência do Município de Alto Alegre dos Parecis](http://transparencia.altoalegre.ro.gov.br/)**: http://transparencia.altoalegre.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Alto Alegre dos Parecis](http://transparencia.altoalegredoparecis.ro.leg.br/portaltransparencia/)**: http://transparencia.altoalegredoparecis.ro.leg.br/portaltransparencia/
+
+### Alto Paraíso
+
+-   **[Portal de Transparência do Município de Alto Paraíso](http://transparencia.altoparaiso.ro.gov.br/transparencia/)**: http://transparencia.altoparaiso.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Alto Paraíso](http://transparencia.camaradealtoparaiso.ro.gov.br/)**: http://transparencia.camaradealtoparaiso.ro.gov.br/
+
+### Buritis
+
+-   **[Portal de Transparência do Município de Buritis](http://transparencia.buritis.ro.gov.br/)**: http://transparencia.buritis.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Buritis](http://transparencia.buritis.ro.leg.br/portaltransparencia/)**: http://transparencia.buritis.ro.leg.br/portaltransparencia/
+
+### Novo Horizonte do Oeste
+
+-   **[Portal de Transparência do Município de Novo Horizonte do Oeste](http://transparencia.novohorizonte.ro.gov.br:5659/transparencia/)**: http://transparencia.novohorizonte.ro.gov.br:5659/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Novo Horizonte do Oeste](http://179.252.90.133:5659/transparencia/)**: http://179.252.90.133:5659/transparencia/
+
+### Cacaulândia
+
+-   **[Portal de Transparência do Município de Cacaulândia](http://transparencia.cacaulandia.ro.gov.br/transparencia/)**: http://transparencia.cacaulandia.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Cacaulândia](http://transparencia.camaradecacaulandia.ro.gov.br/transparencia/)**: http://transparencia.camaradecacaulandia.ro.gov.br/transparencia/
+
+### Campo Novo de Rondônia
+
+-   **[Portal de Transparência do Município de Campo Novo de Rondônia](http://camponovo.ro.gov.br/transparencia/)**: http://camponovo.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Campo Novo de Rondônia](http://transparencia.camponovoderondonia.ro.leg.br/)**: http://transparencia.camponovoderondonia.ro.leg.br/
+
+### Candeias do Jamari
+
+-   **[Portal de Transparência do Município de Candeias do Jamari](http://transparencia.candeiasdojamari.ro.gov.br/)**: http://transparencia.candeiasdojamari.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Candeias do Jamari](http://177.3.248.228:5659/transparencia/)**: http://177.3.248.228:5659/transparencia/
+
+### Castanheiras
+
+-   **[Portal de Transparência do Município de Castanheiras](http://transparencia.castanheiras.ro.gov.br/portaltransparencia/)**: http://transparencia.castanheiras.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Castanheiras](http://177.0.35.253/portaltransparencia/)**: http://177.0.35.253/portaltransparencia/
+
+### Chupinguaia
+
+-   **[Portal de Transparência do Município de Chupinguaia](http://transparencia.chupinguaia.ro.gov.br/transparencia/)**: http://transparencia.chupinguaia.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Chupinguaia](http://transparencia.chupinguaia.ro.leg.br/portaltransparencia/)**: http://transparencia.chupinguaia.ro.leg.br/portaltransparencia/
+
+### Cujubim
+
+-   **[Portal de Transparência do Município de Cujubim](http://transparencia.cujubim.ro.gov.br/)**: http://transparencia.cujubim.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Cujubim](http://187.53.10.198:5659/transparencia/index.php)**: http://187.53.10.198:5659/transparencia/index.php
+
+### Governador Jorge Teixeira
+
+-   **[Portal de Transparência do Município de Governador Jorge Teixeira](http://transparencia.governadorjorgeteixeira.ro.gov.br/)**: http://transparencia.governadorjorgeteixeira.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Governador Jorge Teixeira](http://transparencia.governadorjorgeteixeira.ro.leg.br/)**: http://transparencia.governadorjorgeteixeira.ro.leg.br/
+
+### Itapuã do Oeste
+
+-   **[Portal de Transparência do Município de Itapuã do Oeste](http://transparencia.itapuadooeste.ro.gov.br/transparencia/)**: http://transparencia.itapuadooeste.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Itapuã do Oeste](http://transparencia.camaradeitapuadooeste.ro.gov.br:5659/transparencia/)**: http://transparencia.camaradeitapuadooeste.ro.gov.br:5659/transparencia/
+
+### Ministro Andreazza
+
+-   **[Portal de Transparência do Município de Ministro Andreazza](http://transparencia.ministroandreazza.ro.gov.br/portaltransparencia/)**: http://transparencia.ministroandreazza.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Ministro Andreazza](http://138.122.143.85:8088/portaltransparencia/)**: http://138.122.143.85:8088/portaltransparencia/
+
+### Mirante da Serra
+
+-   **[Portal de Transparência do Município de Mirante da Serra](http://transparencia.mirantedaserra.ro.gov.br/)**: http://transparencia.mirantedaserra.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Mirante da Serra](http://transparencia.mirantedaserra.ro.leg.br/transparencia/)**: http://transparencia.mirantedaserra.ro.leg.br/transparencia/
+
+### Monte Negro
+
+-   **[Portal de Transparência do Município de Monte Negro](http://transparencia.montenegro.ro.gov.br/)**: http://transparencia.montenegro.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Monte Negro](http://transparencia.camarademontenegro.ro.gov.br/)**: http://transparencia.camarademontenegro.ro.gov.br/
+
+### Nova União
+
+-   **[Portal de Transparência do Município de Nova União](http://transparencia.novauniao.ro.gov.br/)**: http://transparencia.novauniao.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Nova União](http://transparencia.novauniao.ro.gov.br/)**: http://transparencia.novauniao.ro.gov.br/
+
+### Parecis
+
+-   **[Portal de Transparência do Município de Parecis](http://transparencia.parecis.ro.gov.br/)**: http://transparencia.parecis.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Parecis](http://www.transparencia.parecis.ro.leg.br/transparencia/)**: http://www.transparencia.parecis.ro.leg.br/transparencia/
+
+### Pimenteiras do Oeste
+
+-   **[Portal de Transparência do Município de Pimenteiras do Oeste](http://www.transparencia.pimenteirasdooeste.ro.gov.br/transparencia/)**: http://www.transparencia.pimenteirasdooeste.ro.gov.br/transparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Pimenteiras do Oeste](http://transparencia.pimenteirasdooeste.ro.leg.br/portaltransparencia/)**: http://transparencia.pimenteirasdooeste.ro.leg.br/portaltransparencia/
+
+### Primavera de Rondônia
+
+-   **[Portal de Transparência do Município de Primavera de Rondônia](http://transparencia.primavera.ro.gov.br/)**: http://transparencia.primavera.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Primavera de Rondônia](http://transparencia.primaveraderondonia.ro.leg.br/)**: http://transparencia.primaveraderondonia.ro.leg.br/
+
+### São Felipe D'Oeste
+
+-   **[Portal de Transparência do Município de São Felipe D'Oeste](http://transparencia.saofelipe.ro.gov.br/portaltransparencia/)**: http://transparencia.saofelipe.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de São Felipe D'Oeste](http://45.233.222.15/portaltransparencia/)**: http://45.233.222.15/portaltransparencia/
+
+### São Francisco do Guaporé
+
+-   **[Portal de Transparência do Município de São Francisco do Guaporé](http://transparencia.saofrancisco.ro.gov.br/)**: http://transparencia.saofrancisco.ro.gov.br/
+
+-   **[Portal da Transparência da Câmara Municipal de São Francisco do Guaporé](http://transparencia.camaradesaofrancisco.ro.gov.br/)**: http://transparencia.camaradesaofrancisco.ro.gov.br/
+
+### Seringueiras
+
+-   **[Portal de Transparência do Município de Seringueiras](http://transparencia.seringueiras.ro.gov.br/)**: http://transparencia.seringueiras.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Seringueiras](http://transparencia.camaradeseringueiras.ro.gov.br/)**: http://transparencia.camaradeseringueiras.ro.gov.br/
+
+### Teixeirópolis
+
+-   **[Portal de Transparência do Município de Teixeirópolis](http://transparencia.teixeiropolis.ro.gov.br/)**: http://transparencia.teixeiropolis.ro.gov.br/
+
+-   **[Portal de Transparência da Câmara Municipal de Teixeirópolis](http://transparencia.teixeiropolis.ro.leg.br/)**: http://transparencia.teixeiropolis.ro.leg.br/
+
+### Theobroma
+
+-   **[Portal de Transparência do Município de Theobroma](http://transparencia.theobroma.ro.gov.br/portaltransparencia/)**: http://transparencia.theobroma.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Theobroma](http://transparencia.theobroma.ro.leg.br/)**: http://transparencia.theobroma.ro.leg.br/
+
+### Urupá
+
+-   **[Portal de Transparência do Município de Urupá](http://transparencia.urupa.ro.gov.br/portaltransparencia/)**: http://transparencia.urupa.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Urupá](http://transparencia.camaradeurupa.ro.gov.br/)**: http://transparencia.camaradeurupa.ro.gov.br/
+
+### Vale do Anari
+
+-   **[Portal de Transparência do Município de Vale do Anari](http://transparencia.valedoanari.ro.gov.br/portaltransparencia/)**: http://transparencia.valedoanari.ro.gov.br/portaltransparencia/
+
+-   **[Portal de Transparência da Câmara Municipal de Vale do Anari](http://transparencia.camaravaledoanari.ro.gov.br/)**: http://transparencia.camaravaledoanari.ro.gov.br/
+
+### Vale do Paraíso
+
+-  **[Portal de Transparência do Município de Vale do Paraíso](http://transparencia.camaravaledoanari.ro.gov.br/)**: http://transparencia.camaravaledoanari.ro.gov.br/
+
+-  **[Portal de Transparência da Câmara Municipal de Vale do Paraíso](http://transparencia.camaradevaledoparaiso.ro.gov.br/)**: http://transparencia.camaradevaledoparaiso.ro.gov.br/


### PR DESCRIPTION
Olá galeros. Estive na CapiConf 2019 e gostei deste projeto, então estarei contribuindo ativamente a partir de agora.
Neste PR adicionei links dos portais de transparência de prefeituras e câmaras municipais de todos os municípios do estado de Rondônia. 
Dito isso, tenho algumas considerações.

- Os links estão na ordem da estimativa do IBGE (ftp://ftp.ibge.gov.br/Estimativas_de_Populacao/Estimativas_2018/estimativa_TCU_2018_20190213.pdf), ou seja, estão classificados pelo código de município IBGE (com exceção de Porto Velho, que foi mantido no topo). Por estar confuso se ordeno por população ou ordem alfabética, decido deixar essa decisão nas mãos da comunidade.

- No site da Câmara Municipal de Costa Marques (https://www.costamarques.ro.leg.br/), existem dois endereços: transparencia.cmcostamarques.ro.gov.br:8080/portaltransparencia/ e um endereço de IP direto http://138.121.27.59:8080/portaltransparencia/
O endereço de IP direto funciona.

- O link do IP direto da Transparência da Câmara Municipal de Espigão do Oeste (http://177.129.125.89/portaltransparencia/) foi adquirido diretamente do site da Câmara Muniicpal (https://espigaodoeste.ro.leg.br/)

- Um município se auto escreve como “Espigão do Oeste”, enquanto no IBGE (ftp://ftp.ibge.gov.br/Estimativas_de_Populacao/Estimativas_2018/estimativa_TCU_2018_20190213.pdf) é escrito “Espigão d’Oeste”. Mantive ambas as nomenclaturas.

- Em 13 de maio de 2019, o site da Prefeitura de Guajará Mirim (http://www.guajaramirim.ro.gov.br/) estava inoperante. O link da Transparência Municipal foi adquirido por meio de consulta ao cache do Google.

- O link do IP direto da Transparência da Câmara Municipal de Guajará-Mirim (http://200.96.206.197:8079/TRANSPARENCIA/) foi adquirido diretamente do site da Câmara Municipal (https://www.guajaramirim.ro.leg.br/)

- Os links de IP direto da Transparência da Câmara Municipal de Jaru (http://177.203.133.115/portaltransparencia// e http://177.203.133.115:5659/transparencia/) foram adquiridos diretamente do site da Câmara Municipal (http://jaru.ro.leg.br/)

- O link do IP direto da Transparência da Câmara Municipal de Ouro Preto do Oeste (http://179.253.49.222:5659/transparencia/) foi adquirido diretamente do site da Câmara Municipal (https://www.ouropretodooeste.ro.leg.br/)

- O link sem subdomínio legislativo ou governamental da Transparência da Câmara Municipal de Santa Luzia D’Oeste (http://transparencia.abase.com.br/home/paginaInicial/nmRX5BhveQo=) foi adquirido diretamente do site da Câmara Municipal (https://santaluziadoeste.ro.leg.br/)

- O site da Câmara Municipal de Vilhena (https://www.vilhena.ro.leg.br/) está com problemas no código e não pode ser acessado. Site da transparência da Câmara Municipal encontrado pelo Cache do Google.

- Apesar de constar no site da prefeitura (http://www.saomiguel.ro.gov.br/), o site da Transparência do Município de São Miguel do Guaporé (http://transparencia.saomiguel.ro.gov.br/portaltransparencia/) não estava acessível no momento da pesquisa (13 de maio de 2019)

- O link de IP direto da Transparência da Câmara Municipal de Novo Horizonte do Oeste (http://179.252.90.133:5659/transparencia/) foi adquirido diretamente do site da Câmara Municipal (https://www.novohorizontedooeste.ro.leg.br/)

- O link de IP direto da Transparência da Câmara Municipal de Candeias do Jamari (http://177.3.248.228:5659/transparencia/) foi adquirido diretamente do site da Câmara Municipal (https://www.candeiasdojamari.ro.leg.br/)

- Apesar de listado no site da Câmara Municipal (https://www.castanheiras.ro.leg.br/), o site da Transparência da Câmara Municipal de Castanheiras (http://177.0.35.253/portaltransparencia/) não estava acessível no momento da pesquisa (13 de maio de 2019)

- A transparência do Município de Cujubim (http://transparencia.cujubim.ro.gov.br/) somente mostra dados do instituto de previdência local, faltando informações base.

- O link de IP direto da Transparência da Câmara Municipal de Cujubim (http://187.53.10.198:5659/transparencia/index.php) foi adquirido diretamente do site da Câmara Municipal (http://camaradecujubim.ro.gov.br/)

- O link de IP direto da Transparência da Câmara Municipal de Ministro Andreazza (http://138.122.143.85:8088/portaltransparencia/) foi adquirido diretamente do site da Câmara Municipal (http://www.cmandreazza.ro.gov.br/)

- O link de IP direto da Transparência da Câmara Municipal de São Felipe D’Oeste (http://45.233.222.15/portaltransparencia/) foi adquirido diretamente do site da Câmara Municipal (https://www.saofelipedoeste.ro.leg.br/)