### PR TITLE
Adicionando cidades do RN

### DIFF
--- a/_states/rio-grande-do-norte.md
+++ b/_states/rio-grande-do-norte.md
@@ -76,10 +76,6 @@ title:  "Rio Grande do Norte"
 
 -  **[Portal da Transparência do Município de Boa Saúde](http://191.241.56.58/transparencia/)**: http://191.241.56.58/transparencia/
 
-### Bodó
-
--  **[Portal da Transparência do Município de Bodó]()**: 
-
 ### Bom Jesus
 
 -  **[Portal da Transparência do Município de Bom Jesus](https://site.bomjesus.rn.gov.br/transparencia-municipal)**: https://site.bomjesus.rn.gov.br/transparencia-municipal
@@ -87,10 +83,6 @@ title:  "Rio Grande do Norte"
 ### Brejinho
 
 -  **[Portal da Transparência do Município de Brejinho](http://www.governotransparente.com.br/6650490)**: http://www.governotransparente.com.br/6650490
-
-### Caiçara do Norte
-
--  **[Portal da Transparência do Município de Caiçara do Norte]()**: 
 
 ### Caiçara do Rio do Vento
 
@@ -356,11 +348,8 @@ title:  "Rio Grande do Norte"
 
 -  **[Portal da Transparência do Município de Mossoró](http://187.19.199.132/transparencia/)**: http://187.19.199.132/transparencia/
 
-### NATAL
-
--  **[Portal da Transparência e Mobilidade Urbana de Natal](http://dados.natal.br/)**: http://dados.natal.br/
-
 ### Natal
 
--   **[Portal da Transparência do Município de Natal](https://natal.rn.gov.br/transparencia/)**: https://natal.rn.gov.br/transparencia/
+-  **[Portal da Transparência do Município de Natal](https://natal.rn.gov.br/transparencia/)**: https://natal.rn.gov.br/transparencia/
 
+-  **[Portal da Transparência da Mobilidade Urbana de Natal](http://dados.natal.br/)**: http://dados.natal.br/

--- a/_states/rio-grande-do-norte.md
+++ b/_states/rio-grande-do-norte.md
@@ -32,9 +32,9 @@ title:  "Rio Grande do Norte"
 
 -  **[Portal da Transparência do Município de Angicos](http://topdown.servehttp.com:8080/Transparencia/pmangicos/)**: http://topdown.servehttp.com:8080/Transparencia/pmangicos/
 
-### Antonio Martins
+### Antônio Martins
 
--  **[Portal da Transparência do Município de Antonio Martins]()**:
+-  **[Portal da Transparência do Município de Antônio Martins](https://antoniomartins.rn.gov.br/portal-da-transparencia/)**: https://antoniomartins.rn.gov.br/portal-da-transparencia/
 
 ### Apodi
 
@@ -126,7 +126,7 @@ title:  "Rio Grande do Norte"
 
 ### Ceará Mirim
 
--  **[Portal da Transparência do Município de Ceará Mirim]()**: 
+-  **[Portal da Transparência do Município de Ceará Mirim](http://topdown.servehttp.com:8080/Transparencia/pmcearamirim/)**: http://topdown.servehttp.com:8080/Transparencia/pmcearamirim/
 
 ### Cerro Corá
 
@@ -294,7 +294,7 @@ title:  "Rio Grande do Norte"
 
 ### Lagoa Salgada
 
--  **[Portal da Transparência do Município de Lagoa Salgada]()**:
+-  **[Portal da Transparência do Município de Lagoa Salgada](https://lagoasalgada.rn.gov.br/transparente/)**: https://lagoasalgada.rn.gov.br/transparente/
 
 ### Lajes
 

--- a/_states/rio-grande-do-norte.md
+++ b/_states/rio-grande-do-norte.md
@@ -4,6 +4,358 @@ title:  "Rio Grande do Norte"
 ---
 ## RIO GRANDE DO NORTE
 
+### Acari
+
+-  **[Portal da Transparência do Município de Acari](https://www.acari.rn.leg.br/transparencia)**: https://www.acari.rn.leg.br/transparencia
+
+### Afonso Bezerra
+
+-  **[Portal da Transparência do Município de Afonso Bezerra](http://afonsobezerra.rn.gov.br/transp/)**: http://afonsobezerra.rn.gov.br/transp/
+
+### Água Nova
+
+-  **[Portal da Transparência do Município de Água Nova](https://aguanova.rn.gov.br/acessoainformacao.php)**: https://aguanova.rn.gov.br/acessoainformacao.php
+
+### Alexandria
+
+-  **[Portal da Transparência do Município de Alexandria](http://www.transparenciaicone.com.br/alexandriarn/portaldatransparencia/)**: http://www.transparenciaicone.com.br/alexandriarn/portaldatransparencia/
+
+### Almino Afonso
+
+-  **[Portal da Transparência do Município de Almino Afonso](http://www.transparenciaicone.com.br/alminoafonsorn/portaldatransparencia/)**: http://www.transparenciaicone.com.br/alminoafonsorn/portaldatransparencia/
+
+### Alto do Rodrigues
+
+-  **[Portal da Transparência do Município de Alto do Rodrigues](http://transparencia.altodorodrigues.rn.gov.br/)**: http://transparencia.altodorodrigues.rn.gov.br/
+
+### Angicos
+
+-  **[Portal da Transparência do Município de Angicos](http://topdown.servehttp.com:8080/Transparencia/pmangicos/)**: http://topdown.servehttp.com:8080/Transparencia/pmangicos/
+
+### Antonio Martins
+
+-  **[Portal da Transparência do Município de Antonio Martins]()**:
+
+### Apodi
+
+-  **[Portal da Transparência do Município de Apodi](https://www.apodi.rn.gov.br/acessoainformacao.php)**: https://www.apodi.rn.gov.br/acessoainformacao.php
+
+### Areia Branca
+
+-  **[Portal da Transparência do Município de Areia Branca](http://areiabranca.rn.gov.br/transparencia/)**: http://areiabranca.rn.gov.br/transparencia/
+
+### Arêz
+
+-  **[Portal da Transparência do Município de Arêz](http://191.241.43.227:8080/transparencia/)**: http://191.241.43.227:8080/transparencia/
+
+### Assú
+
+-  **[Portal da Transparência do Município do Assú](http://assu.rn.gov.br/portal-da-transparencia/)**: http://assu.rn.gov.br/portal-da-transparencia/
+
+### Baia Formosa
+
+-  **[Portal da Transparência do Município de Baia Formosa](http://baiaformosa.rn.gov.br/transparencia)**: http://baiaformosa.rn.gov.br/transparencia
+
+### Baraúna
+
+-  **[Portal da Transparência do Município de Baraúna](http://barauna.rn.gov.br/transp/)**: http://barauna.rn.gov.br/transp/
+
+### Baraúna
+
+-  **[Portal da Transparência do Município de Baraúna](http://barauna.rn.gov.br/transp/)**: http://barauna.rn.gov.br/transp/
+
+### Barcelona
+
+-  **[Portal da Transparência do Município de Barcelona](https://www.barcelona.rn.gov.br/acessoainformacao.php)**: https://www.barcelona.rn.gov.br/acessoainformacao.php
+
+### Bento Fernandes
+
+-  **[Portal da Transparência do Município de Bento Fernandes](http://topdown.servehttp.com:8080/Transparencia/pmbentofernandes/)**: http://topdown.servehttp.com:8080/Transparencia/pmbentofernandes/
+
+### Boa Saúde
+
+-  **[Portal da Transparência do Município de Boa Saúde](http://191.241.56.58/transparencia/)**: http://191.241.56.58/transparencia/
+
+### Bodó
+
+-  **[Portal da Transparência do Município de Bodó]()**: 
+
+### Bom Jesus
+
+-  **[Portal da Transparência do Município de Bom Jesus](https://site.bomjesus.rn.gov.br/transparencia-municipal)**: https://site.bomjesus.rn.gov.br/transparencia-municipal
+
+### Brejinho
+
+-  **[Portal da Transparência do Município de Brejinho](http://www.governotransparente.com.br/6650490)**: http://www.governotransparente.com.br/6650490
+
+### Caiçara do Norte
+
+-  **[Portal da Transparência do Município de Caiçara do Norte]()**: 
+
+### Caiçara do Rio do Vento
+
+-  **[Portal da Transparência do Município de Caiçara do Rio do Vento](http://caicaradoriodovento.rn.gov.br/portal-da-transparencia/)**: http://caicaradoriodovento.rn.gov.br/portal-da-transparencia/
+
+### Caicó
+
+-  **[Portal da Transparência do Município de Caicó](https://caico.rn.gov.br/acessoainformacao.php)**: https://caico.rn.gov.br/acessoainformacao.php
+
+### Campo Grande
+
+-  **[Portal da Transparência do Município de Campo Grande](https://www.campogrande.rn.gov.br/acessoainformacao.php)**: https://www.campogrande.rn.gov.br/acessoainformacao.php
+
+### Campo Redondo
+
+-  **[Portal da Transparência do Município de Campo Redondo](http://186.209.104.139/transparencia/)**: http://186.209.104.139/transparencia/
+
+### Canguaretama
+
+-  **[Portal da Transparência do Município de Canguaretama](http://topdown.servehttp.com:8080/transparencia/PMCanguaretama/)**: http://topdown.servehttp.com:8080/transparencia/PMCanguaretama/
+
+### Caraúbas
+
+-  **[Portal da Transparência do Município de Caraúbas](http://www.caraubas.rn.gov.br/portal-da-transparencia/)**: http://www.caraubas.rn.gov.br/portal-da-transparencia/
+
+### Carnaúba dos Dantas
+
+-  **[Portal da Transparência do Município de Carnaúba dos Dantas](http://170.79.48.23:85/)**: http://170.79.48.23:85/
+
+### Carnaubais
+
+-  **[Portal da Transparência do Município de Carnaubais](https://carnaubais.rn.gov.br/acessoainformacao.php)**: https://carnaubais.rn.gov.br/acessoainformacao.php
+
+### Ceará Mirim
+
+-  **[Portal da Transparência do Município de Ceará Mirim]()**: 
+
+### Cerro Corá
+
+-  **[Portal da Transparência do Município de Cerro Corá](https://www.cerrocora.rn.gov.br/acessoainformacao.php)**: https://www.cerrocora.rn.gov.br/acessoainformacao.php
+
+### Coronel Ezequiel
+
+-  **[Portal da Transparência do Município de Coronel Ezequiel](http://topdown.servehttp.com:8080/transparencia/pmcoronelezequiel/)**: http://topdown.servehttp.com:8080/transparencia/pmcoronelezequiel/
+
+### Coronel João Pessoa
+
+-  **[Portal da Transparência do Município de Coronel João Pessoa](http://www.transparenciaicone.com.br/coroneljoaopessoarn/portaldatransparencia/)**: http://www.transparenciaicone.com.br/coroneljoaopessoarn/portaldatransparencia/
+
+### Cruzeta
+
+-  **[Portal da Transparência do Município de Cruzeta](http://177.107.104.26:8080/transparencia/)**: http://177.107.104.26:8080/transparencia/
+
+### Currais Novos
+
+-  **[Portal da Transparência do Município de Currais Novos](http://prefeituracurraisnovos.com.br/transparencia/)**: http://prefeituracurraisnovos.com.br/transparencia/
+
+### Doutor Severiano
+
+-  **[Portal da Transparência do Município de Doutor Severiano](http://transparenciaicone.com.br/doutorseverianorn/portaldatransparencia/)**: http://transparenciaicone.com.br/doutorseverianorn/portaldatransparencia/
+
+### Encanto
+
+-  **[Portal da Transparência do Município de Encanto](https://www.encanto.rn.gov.br/acessoainformacao.php)**: https://www.encanto.rn.gov.br/acessoainformacao.php
+
+### Equador
+
+-  **[Portal da Transparência do Município de Equador](https://www.equador.rn.gov.br/portal/transparencia-fiscal)**: https://www.equador.rn.gov.br/portal/transparencia-fiscal
+
+### Espirito Santo
+
+-  **[Portal da Transparência do Município de Espirito Santo](http://topdown.servehttp.com:8080/Transparencia/pmespiritosanto/)**: http://topdown.servehttp.com:8080/Transparencia/pmespiritosanto/
+
+### Extremoz
+
+-  **[Portal da Transparência do Município de Extremoz](http://extremoz.rn.gov.br/portal-da-transparencia/)**: http://extremoz.rn.gov.br/portal-da-transparencia/
+
+### Felipe Guerra
+
+-  **[Portal da Transparência do Município de Felipe Guerra](https://www.felipeguerra.rn.gov.br/contas-publicas)**: https://www.felipeguerra.rn.gov.br/contas-publicas
+
+### Fernando Pedroza
+
+-  **[Portal da Transparência do Município de Fernando Pedroza](http://www.governotransparente.com.br/6689489)**: http://www.governotransparente.com.br/6689489
+
+### Florânia
+
+-  **[Portal da Transparência do Município de Florânia](http://168.232.150.196:81/)**: http://168.232.150.196:81/
+
+### Francisco Dantas
+
+-  **[Portal da Transparência do Município de Francisco Dantas](https://www.franciscodantas.rn.gov.br/acessoainformacao.php)**: https://www.franciscodantas.rn.gov.br/acessoainformacao.php
+
+### Frutuoso Gomes
+
+-  **[Portal da Transparência do Município de Frutuoso Gomes](http://cloud.publica.inf.br/clientes/frutuosogomes_pm/portaltransparencia/)**: http://cloud.publica.inf.br/clientes/frutuosogomes_pm/portaltransparencia/
+
+### Galinhos
+
+-  **[Portal da Transparência do Município de Galinhos](http://170.254.212.205:8079/transparencia/)**: http://170.254.212.205:8079/transparencia/
+
+### Goianinha
+
+-  **[Portal da Transparência do Município de Goianinha](http://goianinha.rn.gov.br/transparencia/)**: http://goianinha.rn.gov.br/transparencia/
+
+### Governador Dix-Sept Rosado
+
+-  **[Portal da Transparência do Município de Governador Dix-Sept Rosado](http://topdown.servehttp.com:8080/Transparencia/pmgovdixseptrosado/)**: http://topdown.servehttp.com:8080/Transparencia/pmgovdixseptrosado/
+
+### Grossos
+
+-  **[Portal da Transparência do Município de Grossos](http://168.197.161.13:8079/transparencia/)**: http://168.197.161.13:8079/transparencia/
+
+### Guamaré
+
+-  **[Portal da Transparência do Município de Guamaré](https://guamare.rn.gov.br/portal-da-transparencia/)**: https://guamare.rn.gov.br/portal-da-transparencia/
+
+### Ielmo Marinho
+
+-  **[Portal da Transparência do Município de Ielmo Marinho](https://ielmomarinho.rn.gov.br/transparencia/)**: https://ielmomarinho.rn.gov.br/transparencia/
+
+### Ipanguaçu
+
+-  **[Portal da Transparência do Município de Ipanguaçu](https://ipanguacu.rn.gov.br/transparencia/)**: https://ipanguacu.rn.gov.br/transparencia/
+
+### Ipueira
+
+-  **[Portal da Transparência do Município de Ipueira](http://transparencia.ipueira.rn.gov.br/)**: http://transparencia.ipueira.rn.gov.br/
+
+### Itajá
+
+-  **[Portal da Transparência do Município de Itajá](https://itaja.rn.gov.br/transparencia/)**: https://itaja.rn.gov.br/transparencia/
+
+### Itaú
+
+-  **[Portal da Transparência do Município de Itaú](https://www.itau.rn.gov.br/acessoainformacao.php)**: https://www.itau.rn.gov.br/acessoainformacao.php
+
+### Jaçanã
+
+-  **[Portal da Transparência do Município de Jaçanã](http://topdown.servehttp.com:8080/transparencia/pmjacana/)**: http://topdown.servehttp.com:8080/transparencia/pmjacana/
+
+### Jandaíra
+
+-  **[Portal da Transparência do Município de Jandaíra](http://topdown.servehttp.com:8080/transparencia/pmjandaira/)**: http://topdown.servehttp.com:8080/transparencia/pmjandaira/
+
+### Janduís
+
+-  **[Portal da Transparência do Município de Janduís](http://topdown.servehttp.com:8080/transparencia/pmjanduis/)**: http://topdown.servehttp.com:8080/transparencia/pmjanduis/
+
+### Japi
+
+-  **[Portal da Transparência do Município de Japi](http://japi.rn.gov.br/transparencia-municipal/)**: http://japi.rn.gov.br/transparencia-municipal/
+
+### Jardim de Angicos
+
+-  **[Portal da Transparência do Município de Jardim de Angicos](https://jardimdeangicos.rn.gov.br/transparencia/)**: https://jardimdeangicos.rn.gov.br/transparencia/
+
+### Jardim de Piranhas
+
+-  **[Portal da Transparência do Município de Jardim de Piranhas](http://topdown.servehttp.com:8080/transparencia/pmjardimpiranhas/)**: http://topdown.servehttp.com:8080/transparencia/pmjardimpiranhas/
+
+### Jardim do Seridó
+
+-  **[Portal da Transparência do Município de Jardim do Seridó](http://170.79.48.5:8080/transparencia/)**: http://170.79.48.5:8080/transparencia/
+
+### João Câmara
+
+-  **[Portal da Transparência do Município de João Câmara](http://topdown.servehttp.com:8080/Transparencia/pmjoaocamara/)**: http://topdown.servehttp.com:8080/Transparencia/pmjoaocamara/
+
+### João Dias
+
+-  **[Portal da Transparência do Município de João Dias](https://www.joaodias.rn.gov.br/acessoainformacao.php)**: https://www.joaodias.rn.gov.br/acessoainformacao.php
+
+### José da Penha
+
+-  **[Portal da Transparência do Município de José da Penha](https://www.josedapenha.rn.gov.br/acessoainformacao.php)**: https://www.josedapenha.rn.gov.br/acessoainformacao.php
+
+### Jucurutu
+
+-  **[Portal da Transparência do Município de Jucurutu](http://www.jucurutu.rn.gov.br/portal-da-transparencia/)**: http://www.jucurutu.rn.gov.br/portal-da-transparencia/
+
+### Jundiá
+
+-  **[Portal da Transparência do Município de Jundiá](http://jundia.rn.gov.br/transparencia-municipal/)**: http://jundia.rn.gov.br/transparencia-municipal/
+
+### Lagoa D'Anta
+
+-  **[Portal da Transparência do Município de Lagoa D'Anta](https://lagoadanta.rn.gov.br/transparente/)**: https://lagoadanta.rn.gov.br/transparente/
+
+### Lagoa de Pedras
+
+-  **[Portal da Transparência do Município de Lagoa de Pedras](http://lagoadepedras.rn.gov.br/portaldatransparencia.html)**: http://lagoadepedras.rn.gov.br/portaldatransparencia.html
+
+### Lagoa de Velhos
+
+-  **[Portal da Transparência do Município de Lagoa de Velhos](https://www.governotransparente.com.br/6739489)**: https://www.governotransparente.com.br/6739489
+
+### Lagoa Nova
+
+-  **[Portal da Transparência do Município de Lagoa Nova](http://lagoanova.rn.gov.br/portal-da-transparencia/)**: http://lagoanova.rn.gov.br/portal-da-transparencia/
+
+### Lagoa Salgada
+
+-  **[Portal da Transparência do Município de Lagoa Salgada]()**:
+
+### Lajes
+
+-  **[Portal da Transparência do Município de Lajes](http://lajes.rn.gov.br/transparencia/)**: http://lajes.rn.gov.br/transparencia/
+
+### Lajes Pintadas
+
+-  **[Portal da Transparência do Município de Lajes Pintadas](http://topdown.servehttp.com:8080/transparencia/pmlajespintadas/)**: http://topdown.servehttp.com:8080/transparencia/pmlajespintadas/
+
+### Lucrécia
+
+-  **[Portal da Transparência do Município de Lucrécia](http://cloud.publica.inf.br/clientes/lucrecia_pm/portaltransparencia/)**: http://cloud.publica.inf.br/clientes/lucrecia_pm/portaltransparencia/
+
+### Luís Gomes
+
+-  **[Portal da Transparência do Município de Luís Gomes](https://luisgomes.rn.gov.br/elementor-6617/)**: https://luisgomes.rn.gov.br/elementor-6617/
+
+### Macaíba
+
+-  **[Portal da Transparência do Município de Macaíba](http://186.209.105.226/transparencia/portalMacaiba/index.html)**: http://186.209.105.226/transparencia/portalMacaiba/index.html
+
+### Macau
+
+-  **[Portal da Transparência do Município de Macau](http://transparencia.macau.rn.gov.br/)**: http://transparencia.macau.rn.gov.br/
+
+### Major Sales
+
+-  **[Portal da Transparência do Município de Major Sales](https://www.majorsales.rn.gov.br/acessoainformacao.php)**: https://www.majorsales.rn.gov.br/acessoainformacao.php
+
+### Marcelino Vieira
+
+-  **[Portal da Transparência do Município de Marcelino Vieira](https://marcelinovieira.rn.gov.br/acessoainformacao.php)**: https://marcelinovieira.rn.gov.br/acessoainformacao.php
+
+### Martins
+
+-  **[Portal da Transparência do Município de Martins](http://transparenciabr.sytes.net/RNPMMARTINS/)**: http://transparenciabr.sytes.net/RNPMMARTINS/
+
+### Maxaranguape
+
+-  **[Portal da Transparência do Município de Maxaranguape](https://site.maxaranguape.rn.gov.br/transparencia-municipal)**: https://site.maxaranguape.rn.gov.br/transparencia-municipal
+
+### Messias Targino
+
+-  **[Portal da Transparência do Município de Messias Targino](http://portaldatransparencia.publicsoft.com.br/sistemas/ContabilidadePublica/views/)**: http://portaldatransparencia.publicsoft.com.br/sistemas/ContabilidadePublica/views/
+
+### Montanhas
+
+-  **[Portal da Transparência do Município de Montanhas](http://montanhas.rn.gov.br/portal-de-transparencia/)**: http://montanhas.rn.gov.br/portal-de-transparencia/
+
+### Monte Alegre
+
+-  **[Portal da Transparência do Município de Monte Alegre](https://montealegre.rn.gov.br/transparencia/)**: https://montealegre.rn.gov.br/transparencia/
+
+### Monte das Gameleiras
+
+-  **[Portal da Transparência do Município de Monte das Gameleiras](http://montedasgameleiras.rn.gov.br/transparencia-municipal/)**: http://montedasgameleiras.rn.gov.br/transparencia-municipal/
+
+### Mossoró
+
+-  **[Portal da Transparência do Município de Mossoró](http://187.19.199.132/transparencia/)**: http://187.19.199.132/transparencia/
+
 ### NATAL
 
 -  **[Portal da Transparência e Mobilidade Urbana de Natal](http://dados.natal.br/)**: http://dados.natal.br/


### PR DESCRIPTION
### Adicionando cidades do RN

### Este PR faz o seguinte:

-  Adiciona 85 cidades do Rio Grande do Norte com seus respectivos portais das transparência e em ordem alfabética.
-  Organiza a seção da cidade de Natal, removendo uma das seções e adicionando seu conteúdo na seção restante.