### PR TITLE
Remove X que aparece em cima dos tiles coloridos.

### DIFF
--- a/_sass/components/_tiles.scss
+++ b/_sass/components/_tiles.scss
@@ -67,7 +67,6 @@
 					left: 0;
 					width: 100%;
 					height: 100%;
-					background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100" preserveAspectRatio="none"><style>line { stroke-width: 0.25px; stroke: #ffffff; }</style><line x1="0" y1="0" x2="100" y2="100" /><line x1="100" y1="0" x2="0" y2="100" /></svg>');
 					background-position: center;
 					background-repeat: no-repeat;
 					background-size: 100% 100%;


### PR DESCRIPTION
### Remove X que aparece em cima dos tiles coloridos.

### Este PR faz o seguinte:

- [ ] Inclui uma nova base de dados
- [ ] Inclui nova funcionalidade
- [x] Altera o layout
- [ ] Formatação ou refactor de código
- [ ] Resolve a issue#{id}

---

### Se há mudança de layout ou funcionaliade, foi testado em quais browsers:

Mobile

- Android
  - [ ] Chrome
- iOS
  - [ ] Chrome
  - [ ] Safari

Desktop

- Windows
  - [ ] Chrome
  - [ ] Firefox
- MacOs
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
- Linux
  - [ ] Chrome
  - [ ] Firefox

---

# Descrição

Removido o X que aparece sobre os tiles coloridos melhorando a visibilidade do conteúdo dos mesmos.