### PR TITLE
Adiciona Geoportal e ObservaNit, de Niteroi

### DIFF
--- a/_states/rio-de-janeiro.md
+++ b/_states/rio-de-janeiro.md
@@ -194,6 +194,8 @@ title: 'Rio de Janeiro'
 ### NITERÓI
 
 - **[Prefeitura de Niterói](http://portais.niteroi.rj.gov.br/portal-da-transparencia/)**: http://portais.niteroi.rj.gov.br/portal-da-transparencia/
+- **[Geoportal Civitas](https://geo.niteroi.rj.gov.br/civitasgeoportal/)**: https://geo.niteroi.rj.gov.br/civitasgeoportal/
+- **[Observatório de Indicadores](http://observa.niteroi.rj.gov.br/)**: http://observa.niteroi.rj.gov.br/
 
 ### NOVA FRIBURGO
 

--- a/_states/rio-de-janeiro.md
+++ b/_states/rio-de-janeiro.md
@@ -193,9 +193,9 @@ title: 'Rio de Janeiro'
 
 ### NITERÓI
 
-- **[Prefeitura de Niterói](http://portais.niteroi.rj.gov.br/portal-da-transparencia/)**: http://portais.niteroi.rj.gov.br/portal-da-transparencia/
 - **[Geoportal Civitas](https://geo.niteroi.rj.gov.br/civitasgeoportal/)**: https://geo.niteroi.rj.gov.br/civitasgeoportal/
 - **[Observatório de Indicadores](http://observa.niteroi.rj.gov.br/)**: http://observa.niteroi.rj.gov.br/
+- **[Prefeitura de Niterói](http://portais.niteroi.rj.gov.br/portal-da-transparencia/)**: http://portais.niteroi.rj.gov.br/portal-da-transparencia/
 
 ### NOVA FRIBURGO
 


### PR DESCRIPTION
### Adiciona portais de dados da Prefeitura de Niterói

### Este PR faz o seguinte:

- [X] Inclui uma nova base de dados
- [ ] Inclui nova funcionalidade
- [ ] Altera o layout
- [ ] Formatação ou refactor de código
- [ ] Resolve a issue#{id}

---

# Descrição
Adiciona na lista de bases de dados do Estado do Rio de Janeiro o portal de dados geoespaciais (Geoportal Civitas) e o portal do Observatório de Indicadores (ObservaNit) da Prefeitura do Município de Niterói - RJ.